### PR TITLE
Added Placeholder visibility settings

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -1,5 +1,7 @@
+
 import React from 'react'
 import { View, TextInput } from 'react-native'
+import PropTypes from 'prop-types'
 
 import Error, { pickErrorProps } from '../Error'
 import Icon, { pickIconProps } from '../Icon'
@@ -10,7 +12,9 @@ import { defaultProps, propTypes, pickTextInputProps } from './props'
 import * as styles from './styles'
 
 export default class ReinputInput extends React.Component {
-  static propTypes = propTypes
+  /** @type {PropTypes.InferProps<typeof propTypes>} */
+  static propTypes = { ...propTypes, ...TextInput.propTypes }
+  /** @type {import('prop-types').InferProps<typeof propTypes>} */
   static defaultProps = defaultProps
 
   constructor (props) {
@@ -19,7 +23,7 @@ export default class ReinputInput extends React.Component {
     this.state = {
       focused: false,
       height: props.fontSize * styles.SCALE_FACTOR,
-      value: props.defaultValue
+      value: props.value != null ? props.value : props.defaultValue
     }
   }
 
@@ -33,13 +37,13 @@ export default class ReinputInput extends React.Component {
     this.props.onBlur(...args)
   }
 
-  handleChangeText = (value, ...args) => {
-    if (!this.hasPropValue()) {
+  getValue = () => { return this.isValueLocked() ? this.props.value : this.state.value; }
+  setValue = (value, ...args) => {
+    if ( ! this.isValueLocked()) {
       this.setState({ value })
     }
     this.props.onChangeText(value, ...args)
   }
-
   handleContentSizeChange = (event) => {
     const { onContentSizeChange, fontSize } = this.props
     const { height } = event.nativeEvent.contentSize
@@ -51,7 +55,7 @@ export default class ReinputInput extends React.Component {
     onContentSizeChange(event)
   }
 
-  hasPropValue = () => this.props.value !== undefined
+  isValueLocked = () => this.props.value !== undefined
 
   hasValueWithContent = (value) => {
     return typeof value === 'string' && value.length > 0
@@ -66,7 +70,7 @@ export default class ReinputInput extends React.Component {
 
   render () {
     const { focused } = this.state
-    const value = this.hasPropValue() ? this.props.value : this.state.value
+    const value = this.getValue()
     const hasValue = this.hasValueWithContent(value)
 
     return (
@@ -82,12 +86,12 @@ export default class ReinputInput extends React.Component {
             <TextInput
               {...pickTextInputProps(this.props)}
               onBlur={this.handleBlur}
-              onChangeText={this.handleChangeText}
+              onChangeText={this.setValue}
               onContentSizeChange={this.handleContentSizeChange}
               onFocus={this.handleFocus}
               placeholder={undefined}
               ref={this.register}
-              style={styles.input(this.props, this.state.height)}
+              style={styles.input(this.props, this.state.height, hasValue)}
               underlineColorAndroid='transparent'
               value={value}
             />

--- a/src/Input/props.js
+++ b/src/Input/props.js
@@ -1,34 +1,25 @@
-import PropTypes from 'prop-types'
+import PropTypes, { InferProps } from 'prop-types'
 import { TextInput } from 'react-native'
 
 import { BASE_UNIT, BLACK, FONT } from '../services/constants'
 import pick from '../services/pick'
 import * as ErrorProps from '../Error/props'
 
+import * as LabelProps from '../Label/props'
+import * as PlaceholderProps from '../Placeholder/props'
+import * as IconProps from '../Icon/props'
+import * as UnderlineProps from '../Underline/props'
+
+
 const noop = () => {}
 
-export const defaultProps = {
-  ...ErrorProps.defaultProps,
-  accessible: true,
-  color: BLACK,
-  fontSize: FONT,
-  fontWeight: 'normal',
-  marginBottom: BASE_UNIT,
-  onBlur: noop,
-  onChangeText: noop,
-  onContentSizeChange: noop,
-  onFocus: noop,
-  paddingBottom: BASE_UNIT,
-  paddingLeft: 0,
-  paddingRight: 0,
-  paddingTop: BASE_UNIT * 3,
-  register: function () {},
-  value: undefined
-}
-
 export const propTypes = {
-  ...TextInput.propTypes,
+  //...TextInput.propTypes, // Breaks IDE auto-completion
   ...ErrorProps.propTypes,
+  ...LabelProps.propTypes,
+  ...PlaceholderProps.propTypes,
+  ...IconProps.propTypes,
+  ...UnderlineProps.propTypes,
   activeColor: PropTypes.string,
   color: PropTypes.string,
   fontFamily: PropTypes.string,
@@ -52,6 +43,26 @@ export const propTypes = {
   paddingRight: PropTypes.number,
   paddingTop: PropTypes.number,
   register: PropTypes.func.isRequired
+}
+
+/** @type {InferProps<typeof propTypes>} */
+export const defaultProps = {
+  ...ErrorProps.defaultProps,
+  accessible: true,
+  color: BLACK,
+  fontSize: FONT,
+  fontWeight: 'normal',
+  marginBottom: BASE_UNIT,
+  onBlur: noop,
+  onChangeText: noop,
+  onContentSizeChange: noop,
+  onFocus: noop,
+  paddingBottom: BASE_UNIT,
+  paddingLeft: 0,
+  paddingRight: 0,
+  paddingTop: BASE_UNIT * 3,
+  register: function () {},
+  value: undefined
 }
 
 export const pickTextInputProps = (props) => {

--- a/src/Input/styles.js
+++ b/src/Input/styles.js
@@ -21,7 +21,7 @@ export const container = (props) => ({
   flex: 1
 })
 
-export const input = (props = {}, stateHeight) => {
+export const input = (props = {}, stateHeight, hasValue) => {
   const autogrowHeight = (props.multiline && props.height) ? props.height : stateHeight
   const multilineHeight = props.multiline ? autogrowHeight : props.fontSize * SCALE_FACTOR
   const height = props.paddingTop + props.paddingBottom + multilineHeight
@@ -40,6 +40,7 @@ export const input = (props = {}, stateHeight) => {
 
   return {
     ...styles,
+    color: hasValue ? styles.color : 'transparent',
     ...Platform.select({
       ios: { height },
       android: {

--- a/src/Placeholder/Placeholder.js
+++ b/src/Placeholder/Placeholder.js
@@ -1,18 +1,27 @@
 import React from 'react'
 import { Text } from 'react-native'
 
-import { defaultProps, propTypes } from './props'
+import { defaultProps, propTypes, PlaceholderVisibility } from './props'
 import * as styles from './styles'
 
 export default class ReinputPlaceholder extends React.Component {
   static propTypes = propTypes
+  /** @type {import('prop-types').InferProps<typeof propTypes>} */
   static defaultProps = defaultProps
 
   render () {
-    return this.props.placeholder && !this.props.hasValue && this.props.focused ? (
-      <Text numberOfLines={1} pointerEvents="none" style={styles.placeholder(this.props)}>
-        {this.props.placeholder}
-      </Text>
-    ) : null
+    if ( this.props.placeholder && ! this.props.hasValue
+        && (this.props.placeholderVisibility === PlaceholderVisibility.Always
+          || (this.props.placeholderVisibility === this.props.focused)
+        ))
+    {
+      return (
+        <Text numberOfLines={1} pointerEvents="none"
+          style= {styles.placeholder(this.props)}>
+          {this.props.placeholder}
+        </Text>
+      );
+    }
+    return null;
   }
 }

--- a/src/Placeholder/props.js
+++ b/src/Placeholder/props.js
@@ -3,6 +3,13 @@ import PropTypes from 'prop-types'
 import { GRAY } from '../services/constants'
 import pick from '../services/pick'
 
+export const PlaceholderVisibility = {
+    Always: undefined,
+    Never: null,
+    OnFocus: true,
+    OnBlur: false,
+}
+
 export const propTypes = {
   focused: PropTypes.bool,
   fontFamily: PropTypes.string,
@@ -14,13 +21,17 @@ export const propTypes = {
   paddingRight: PropTypes.number,
   paddingTop: PropTypes.number,
   placeholder: PropTypes.string,
-  placeholderColor: PropTypes.string
+  placeholderColor: PropTypes.string,
+  placeholderOpacity: PropTypes.number,
+  placeholderVisibility: PropTypes.oneOf(PlaceholderVisibility),
 }
 
 export const defaultProps = {
-  placeholderColor: GRAY
+  placeholderColor: GRAY,
+  placeholderOpacity: 1,
+  placeholderVisibility: PlaceholderVisibility.Always
 }
 
-export const pickPlaceholderProps = (props, value) => {
+export const pickPlaceholderProps = (props) => {
   return pick(props, Object.keys(propTypes))
 }

--- a/src/Placeholder/styles.js
+++ b/src/Placeholder/styles.js
@@ -12,7 +12,7 @@ export const placeholder = (props = {}) => ({
   ]),
   backgroundColor: 'transparent',
   color: props.placeholderColor,
-  opacity: (props.focused && !props.hasValue) ? 1 : 0,
+  opacity: props.placeholderOpacity,
   position: 'absolute',
   top: 2
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,6 @@
 export { default } from './Input'
+export { propTypes, defaultProps } from './Input/props'
+
 export { default as ReinputButton } from './Button'
+
+export { PlaceholderVisibility } from './Placeholder/props'


### PR DESCRIPTION
1. Added few `JS-Doc` comments to enable IDE auto-completion
2. Added Placeholder visibility settings
   - `Always`: will be visible unless `value` is set
   - `Never`: will be never visible
   - `OnFocus`: will be only visible when component has focus, but unless `value` is set
   - `OnBlur`: will be visible unless component has focus or the `value` is set
3. Fixed that both `Placeholder` and `TextInput` where visible, the issue happened when the very first letter was typed (in a single frame, only the `TextInput` got updated, and later the `state` was set)

**Edit:** You can debug point-number-3 using `color: hasValue ? styles.color : 'red'` in `.\src\Input\styles.js`, (currently to workaround the issue it is "`color: hasValue ? styles.color : 'transparent'`") .