### PR TITLE
Fixed ReinputButton and added errorStyle-prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ How `placeholderVisibility` works?
 
 ```
 {
-    Always: undefined,
+    Always: 1,
     Never: null,
     OnFocus: true,
     OnBlur: false,
@@ -122,8 +122,10 @@ Name                  | Type               | Default
 :-------------------- |:------------------ |:----------
 error                 | String             |
 errorColor            | String             | `#fc1f4a`
-errorFontSize         | Number             | `12`
-errorPaddingTop       | Number             | `8`
+errorStyle            | TextStyle          |
+errorStyle.fontSize   | Number             | `12`
+errorStyle.paddingTop | Number             | `4`
+errorStyle.paddingBottom| Number           | `4`
 
 And **also** all the [TextInput](https://facebook.github.io/react-native/docs/textinput.html#props) properties will work.
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -33,34 +33,39 @@ export default class ReinputButton extends React.Component {
     const height = this.props.fontSize * styles.SCALE_FACTOR
 
     return (
-      <View style={stylesInput.row}>
+      <View
+        onLayout={this.props.onLayout}
+        style={[stylesInput.row, this.props.style]}
+      >
         <Icon {...pickIconInternalProps(this.props)}
           icon={this.props.icon}
+          marginTop={this.props.label ? this.props.labelSpacingTop : 0}
         />
         <View style={stylesInput.container(this.props)}>
           <View
             accessible={this.props.accessible}
             accessibilityLabel={this.props.accessibilityLabel || this.props.label}
+            style={{ backgroundColor: this.props.backgroundColor }}
           >
+            <Label {...pickLabelProps({...this.props, hasValue})} />
             <TouchableOpacity
               {...pickTouchableOpacityProps(this.props)}
               onPress={this.onPress()}
               ref={this.props.register}
-              style={styles.transparent()}
+              style={styles.transparent}
             >
-              <View>
-                <Label {...pickLabelProps({...this.props, hasValue})} />
-                <Text
-                  numberOfLines={1}
-                  pointerEvents='none'
-                  style={[stylesInput.input(this.props, height), styles.input(this.props)]}
-                >
-                  {hasValue && this.props.value}
-                </Text>
-              </View>
+              <Text
+                numberOfLines={1}
+                pointerEvents='none'
+                style={[stylesInput.input(this.props, height), styles.input(this.props)]}
+              >
+                {hasValue && this.props.value}
+              </Text>
             </TouchableOpacity>
             <Icon {...pickIconInternalProps(this.props)}
-              overlay icon={this.props.iconOverlay} />
+              icon={this.props.iconOverlay}
+              overlay
+            />
             <Underline {...pickUnderlineProps({...this.props})} />
           </View>
           <Error {...pickErrorProps(this.props)} />

--- a/src/Button/props.js
+++ b/src/Button/props.js
@@ -4,20 +4,28 @@ import { TouchableOpacity } from 'react-native'
 import { BASE_UNIT, BLACK, FONT } from '../services/constants'
 import pick from '../services/pick'
 import * as ErrorProps from '../Error/props'
+import * as IconProps from '../Icon/props'
+import * as LabelProps from '../Label/props'
+import * as UnderlineProps from '../Underline/props'
 
 const noop = () => {}
 
 export const propTypes = {
   // ...TouchableOpacity.propTypes, // Breaks IDE auto-completion
   ...ErrorProps.propTypes,
+  ...IconProps.internalPropTypes,
+  ...LabelProps.internalPropTypes,
+  ...UnderlineProps.internalPropTypes,
   activeColor: PropTypes.string,
+  backgroundColor: PropTypes.string,
   color: PropTypes.string,
   fontFamily: PropTypes.string,
   fontSize: PropTypes.number,
   fontWeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   height: PropTypes.number,
-  icon: PropTypes.node,
-  iconOverlay: PropTypes.node,
+  icon: PropTypes.any,
+  iconOverlay: PropTypes.any,
+  labelSpacingTop: PropTypes.number,
   marginBottom: PropTypes.number,
   marginLeft: PropTypes.number,
   marginRight: PropTypes.number,
@@ -25,30 +33,30 @@ export const propTypes = {
   maxHeight: PropTypes.number,
   minHeight: PropTypes.number,
   onPress: PropTypes.func,
+  onLayout: PropTypes.func,
   paddingBottom: PropTypes.number,
   paddingLeft: PropTypes.number,
   paddingRight: PropTypes.number,
   paddingTop: PropTypes.number,
-  register: PropTypes.func.isRequired
+  register: PropTypes.func.isRequired,
+  value: PropTypes.string
 }
 
-/**
- * @typedef {PropTypes.InferProps<typeof propTypes>} ReinputButtonProps
- * @typedef {import('react-native').TouchableOpacityProps} TouchableOpacityProps
- * @type {ReinputButtonProps&TouchableOpacityProps}
-*/
+/** @type {import('../types').ReinputButtonProps} */
 export const defaultProps = {
   ...ErrorProps.defaultProps,
   accessible: true,
   color: BLACK,
   fontSize: FONT,
   fontWeight: 'normal',
+  labelSpacingTop: BASE_UNIT * 2,
   marginBottom: BASE_UNIT,
+  marginTop: 0,
   onPress: noop,
-  paddingBottom: BASE_UNIT,
+  paddingBottom: 0,
   paddingLeft: 0,
   paddingRight: 0,
-  paddingTop: BASE_UNIT * 3,
+  paddingTop: BASE_UNIT / 2,
   register: function () {},
   value: null
 }

--- a/src/Button/styles.js
+++ b/src/Button/styles.js
@@ -8,6 +8,6 @@ export const hidden = () => ({
   width: 0
 })
 
-export const transparent = () => ({
+export const transparent = {
   backgroundColor: 'transparent'
-})
+}

--- a/src/Error/Error.js
+++ b/src/Error/Error.js
@@ -16,7 +16,7 @@ export default class ReinputError extends React.Component {
     return this.props.error ? (
       <Text
         numberOfLines={this.props.errorMaxLines}
-        style={styles.error(this.props)}
+        style={[styles.error, {color: this.props.errorColor}, this.props.errorStyle]}
       >
         {this.props.error}
       </Text>

--- a/src/Error/props.js
+++ b/src/Error/props.js
@@ -1,29 +1,19 @@
 import PropTypes from 'prop-types'
 
-import { BASE_UNIT, RED, FONT_SMALL } from '../services/constants'
+import { RED } from '../services/constants'
 import pick from '../services/pick'
 
 export const propTypes = {
   error: PropTypes.string,
-  errorBackgroundColor: PropTypes.string,
   errorColor: PropTypes.string,
-  errorFontSize: PropTypes.number,
-  errorMarginLeft: PropTypes.number,
-  errorMarginRight: PropTypes.number,
   errorMaxLines: PropTypes.number,
-  errorPaddingBottom: PropTypes.number,
-  errorPaddingLeft: PropTypes.number,
-  errorPaddingRight: PropTypes.number,
-  errorPaddingTop: PropTypes.number
+  errorStyle: PropTypes.object
 }
 
 /** @type {PropTypes.InferProps<typeof propTypes>} */
 export const defaultProps = {
   errorColor: RED,
-  errorFontSize: FONT_SMALL,
-  errorMaxLines: 2,
-  errorPaddingBottom: BASE_UNIT / 2,
-  errorPaddingTop: BASE_UNIT / 2
+  errorMaxLines: 2
 }
 
 export const pickErrorProps = (props) => {

--- a/src/Error/styles.js
+++ b/src/Error/styles.js
@@ -1,16 +1,10 @@
-import { BASE_UNIT } from '../services/constants'
+import { BASE_UNIT, FONT_SMALL } from '../services/constants'
 
-export const error = (props = {}) => ({
-  backgroundColor: props.errorBackgroundColor,
-  color: props.errorColor,
-  fontSize: props.errorFontSize,
-  marginLeft: props.errorMarginLeft,
-  marginRight: props.errorMarginRight,
-  paddingBottom: props.errorPaddingBottom,
-  paddingLeft: props.errorPaddingLeft,
-  paddingRight: props.errorPaddingRight,
-  paddingTop: props.errorPaddingTop
-})
+export const error = {
+  fontSize: FONT_SMALL,
+  paddingBottom: BASE_UNIT / 2,
+  paddingTop: BASE_UNIT / 2
+}
 
 export const placeholder = () => ({
   height: BASE_UNIT * 4

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -1,8 +1,15 @@
 import React from 'react'
-import { TouchableOpacity, Image } from 'react-native'
+import { TouchableOpacity, View, Image } from 'react-native'
 
 import { propTypes, defaultProps } from './props'
 import * as styles from './styles'
+
+export function Container(props) {
+  const { onPress } = props;
+  return onPress
+    ? <TouchableOpacity activeOpacity={1} {...props}/>
+    : <View pointerEvents="none" {...props} />;
+}
 
 /** @augments {React.Component<typeof defaultProps, {}>} */
 export default class ReinputIcon extends React.Component {
@@ -14,16 +21,14 @@ export default class ReinputIcon extends React.Component {
     if (!icon) {
       return null
     }
-
     return (
-      <TouchableOpacity
+      <Container
         accessible={false}
-        activeOpacity={1}
         onPress={onPress}
         style={styles.icon(this.props)}
       >
         {React.isValidElement(icon) ? icon : <Image source={icon} />}
-      </TouchableOpacity>
+      </Container>
     )
   }
 }

--- a/src/Icon/styles.js
+++ b/src/Icon/styles.js
@@ -4,8 +4,10 @@ export const overlay = {
   alignItems: 'center',
   justifyContent: 'center',
   position: 'absolute',
+  // Stretch vertically
+  bottom: 0,
   top: 0,
-  bottom: 0, // Stretch vertically
+
   right: BASE_UNIT
 }
 

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -84,7 +84,7 @@ export default class ReinputInput extends React.Component {
         <Icon {...pickIconInternalProps(this.props)}
           icon={this.props.icon}
           onPress={this.focus}
-          marginTop={this.props.label && this.props.labelSpacingTop}
+          marginTop={this.props.label ? this.props.labelSpacingTop : 0}
         />
         <View style={styles.container(this.props)}>
           <View
@@ -108,7 +108,6 @@ export default class ReinputInput extends React.Component {
             />
             <Icon {...pickIconInternalProps(this.props)}
               icon={this.props.iconOverlay}
-              onPress={this.focus}
               overlay
             />
             <Underline {...pickUnderlineProps({ ...this.props, focused })} />

--- a/src/Input/props.js
+++ b/src/Input/props.js
@@ -48,11 +48,7 @@ export const propTypes = {
   style: PropTypes.node
 }
 
-/**
- * @typedef {PropTypes.InferProps<typeof propTypes>} ReinputProps
- * @typedef {import('react-native').TextInputProps} TextInputProps
- * @type {ReinputProps&TextInputProps}
-*/
+/** @type {import('../types').ReinputProps} */
 export const defaultProps = {
   ...ErrorProps.defaultProps,
   accessible: true,
@@ -61,7 +57,7 @@ export const defaultProps = {
   fontSize: FONT,
   fontWeight: 'normal',
   labelSpacingTop: BASE_UNIT * 2,
-  marginBottom: 0,
+  marginBottom: BASE_UNIT,
   marginTop: 0,
   onBlur: noop,
   onChangeText: noop,

--- a/src/Input/styles.js
+++ b/src/Input/styles.js
@@ -21,14 +21,17 @@ export const cell = {
   justifyContent: 'center'
 }
 
-export const container = (props) => ({
-  alignSelf: 'flex-start',
-  marginBottom: props.marginBottom,
-  marginLeft: props.marginLeft,
-  marginRight: props.marginRight,
-  marginTop: props.marginTop + (props.label ? props.labelSpacingTop : 0),
-  flex: 1
-})
+export const container = (props) => {
+  const { marginTop = 0, labelSpacingTop = 0 } = props;
+  return {
+    alignSelf: 'flex-start',
+    marginBottom: props.marginBottom,
+    marginLeft: props.marginLeft,
+    marginRight: props.marginRight,
+    marginTop: marginTop + (props.label ? labelSpacingTop : 0),
+    flex: 1
+  }
+}
 
 export const input = (props = {}, stateHeight, hasValue) => {
   const autogrowHeight = (props.multiline && props.height) ? props.height : stateHeight

--- a/src/Placeholder/Placeholder.js
+++ b/src/Placeholder/Placeholder.js
@@ -16,7 +16,7 @@ export default class ReinputPlaceholder extends React.Component {
         )) {
       return (
         <Text numberOfLines={1} pointerEvents="none"
-          style= {styles.placeholder(this.props)}>
+          style={styles.placeholder(this.props)}>
           {this.props.placeholder}
         </Text>
       )

--- a/src/Placeholder/props.js
+++ b/src/Placeholder/props.js
@@ -4,7 +4,7 @@ import { GRAY } from '../services/constants'
 import pick from '../services/pick'
 
 export const PlaceholderVisibility = {
-  Always: undefined,
+  Always: 1,
   Never: null,
   OnFocus: true,
   OnBlur: false
@@ -14,7 +14,7 @@ export const internalPropTypes = {
   placeholder: PropTypes.string,
   placeholderColor: PropTypes.string,
   placeholderOpacity: PropTypes.number,
-  placeholderVisibility: PropTypes.bool
+  placeholderVisibility: PropTypes.oneOfType([PropTypes.number, PropTypes.bool])
 }
 
 export const propTypes = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,16 @@
+import { InferProps } from 'prop-types';
+import {
+  StyleProp, TextStyle,
+  TextInputProps, TouchableOpacityProps
+} from 'react-native';
+
+export type TextStyleProp = StyleProp<TextStyle>;
+export type ErrorStyleProp = { errorStyle?: TextStyleProp }
+
+export type ReinputProps = TextInputProps
+  & InferProps<typeof import('./Input/props').propTypes>
+  & ErrorStyleProp
+
+export type ReinputButtonProps = TouchableOpacityProps
+  & InferProps<typeof import('./Button/props').propTypes>
+  & ErrorStyleProp


### PR DESCRIPTION
1. Fixed that `ReinputButton` crashed when `labelSpacingTop`-prop was not set
   - Have both added `labelSpacingTop` to default-props, and made it optional (using something like `const {labelSpacingTop = 0} = props;`)

2. Changed `PlaceholderVisibility.Always` to `1` instead of `undefined`
    - When merging `Reinput` default-props, for example by merging like "`MySubclass.defualtProps = {...Reinput.defaultProps, PlaceholderVisibility.Always}`", the `undefined` was ignored, and the value already sat on `Reinput.defaultProps` (namely `true`) was used.

3. Added `errorStyle`-prop (the related `JSDoc`s to enable style auto-completion for it caused number 4)
    - fortunately, removing old props causes IDE warnings, but not any runtime crash (I mean, in case anyone is already using the previous version, an update will not break anything).
    - On all other parts `errorColor`-prop is still used, but on the error message itself, the `errorColor`-prop is only used when `errorStyle.color` is not set

4. Combined some of the JSDocs into the `types.d.ts` file to keep it DRY
5. Made `ReinputIcon` invisible for touch events when its `onPress`-prop is not set
6. According to a designer, the `Label` of `ReinputButton` should not change its opacity when it is outside the Button.
    - Our idea was that the `Label` is the default-text, and should change to further instructions once we click the button-component.
    - To achieve this, have moved the `Label` outside of the `TouchableOpacity`.
    - As you see in the below preview, the text provided by `value`-prop still changes its opacity.

## ReinputButton Preview:
![reinput-button](https://user-images.githubusercontent.com/31405473/59681237-ab117900-91e8-11e9-83c0-415013670ee4.gif)

```tsx
let sampleVariable;
// ...
<Button
  icon={<Image source={require('./icon.png')} />}
  iconOverlay={require('./icon.png')}
  label="A good test-label"
  value={sampleVariable}
  style={{ backgroundColor: 'white' }}
  backgroundColor="blue"
  onPress={() => { sampleVariable = "New button text"; this.forceUpdate() }}
  errorStyle={{ backgroundColor: 'yellow', padding: 4 }}
  error="some error, with a very very long description and it gets even longer and longer; believe me, it is a very very long description and it gets even longer and longer"
  // register={v => this.loginButton = v}
/>
```
