### PR TITLE
Added large images support for "iconOverlay"

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -66,8 +66,8 @@ export default class ReinputButton extends React.Component {
               icon={this.props.iconOverlay}
               overlay
             />
-            <Underline {...pickUnderlineProps({...this.props})} />
           </View>
+          <Underline {...pickUnderlineProps({...this.props})} />
           <Error {...pickErrorProps(this.props)} />
         </View>
       </View>

--- a/src/Button/props.js
+++ b/src/Button/props.js
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types'
 import { TouchableOpacity } from 'react-native'
 
-import { BASE_UNIT, BLACK, FONT } from '../services/constants'
+import { BASE_UNIT, BLACK, FONT, noop } from '../services/constants'
 import pick from '../services/pick'
 import * as ErrorProps from '../Error/props'
 import * as IconProps from '../Icon/props'
 import * as LabelProps from '../Label/props'
 import * as UnderlineProps from '../Underline/props'
-
-const noop = () => {}
 
 export const propTypes = {
   // ...TouchableOpacity.propTypes, // Breaks IDE auto-completion

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -31,7 +31,18 @@ export default class ReinputIcon extends React.Component {
         onPress={onPress}
         style={styles.icon(this.props)}
       >
-        {React.isValidElement(icon) ? icon : <Image source={icon} />}
+        {
+          React.isValidElement(icon)
+            ? icon
+            : <Image
+              resizeMode='contain'
+              source={icon}
+              style={{
+                flex: 1, aspectRatio: 1,
+                maxHeight: this.props.overlay ? '85%' : this.props.iconHeight
+              }}
+            />
+        }
       </Container>
     )
   }

--- a/src/Icon/props.js
+++ b/src/Icon/props.js
@@ -6,9 +6,9 @@ import { BASE_UNIT } from '../services/constants'
 export const ICON_SIZE = BASE_UNIT * 6
 
 export const internalPropTypes = {
-  iconHeight: PropTypes.number,
+  iconHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   iconPaddingTop: PropTypes.number,
-  iconWidth: PropTypes.number
+  iconWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
 
 export const propTypes = {

--- a/src/Icon/styles.js
+++ b/src/Icon/styles.js
@@ -1,7 +1,7 @@
 import { BASE_UNIT } from '../services/constants'
 
 export const overlay = {
-  alignItems: 'center',
+  alignItems: 'flex-end',
   justifyContent: 'center',
   position: 'absolute',
   // Stretch vertically

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -110,8 +110,8 @@ export default class ReinputInput extends React.Component {
               icon={this.props.iconOverlay}
               overlay
             />
-            <Underline {...pickUnderlineProps({ ...this.props, focused })} />
           </View>
+          <Underline {...pickUnderlineProps({ ...this.props, focused })} />
           <Error {...pickErrorProps(this.props)} />
         </View>
       </View>

--- a/src/Input/props.js
+++ b/src/Input/props.js
@@ -1,15 +1,13 @@
 import PropTypes from 'prop-types'
 import { TextInput } from 'react-native'
 
-import { BASE_UNIT, BLACK, FONT } from '../services/constants'
+import { BASE_UNIT, BLACK, FONT, noop } from '../services/constants'
 import pick from '../services/pick'
 import * as ErrorProps from '../Error/props'
 import * as IconProps from '../Icon/props'
 import * as LabelProps from '../Label/props'
 import * as PlaceholderProps from '../Placeholder/props'
 import * as UnderlineProps from '../Underline/props'
-
-const noop = () => { }
 
 export const propTypes = {
   // ...TextInput.propTypes, // Breaks IDE auto-completion

--- a/src/services/constants.js
+++ b/src/services/constants.js
@@ -6,3 +6,5 @@ export const FONT = 15
 export const FONT_SMALL = 12
 export const GRAY = '#757575'
 export const RED = '#fc1f4a'
+
+export const noop = () => { }


### PR DESCRIPTION
1. Fixed that `iconOverlay` was behind the `Underline`, by moving `Underline` one level out
    - The `absolute` positioned `ReinputIcon` has the same height as its parent (thanks to `top: 0, bottom: 0` style settings), but it was behind and/or over the underline (as long as the underline was part of its parent)
    - I compared screenshots and this only changes the size of the overlay-icon and does not affect the size and/or rendering of `ReinputInput` or `ReinputButton` components.

2. Made `ReinputIcon`'s default Image-component `contain` the image (to support large images)
3. ~Added `iconPadding`-prop to make `ReinputIcon`-component render by default as small as before.~
4. ~Added size-related property descriptions to the `README.md` file~

**Update:**

5. As suggested, have just enforced a fixed icon size, to achieve this:
    -  made `ReinputIcons`'s default Image-component use `maxHeight` instead of `width`
    - Tried to keep `iconOverlay`'s size both responsive and as small as before, by using `'85%'` when `overlay`-prop is set to `true`
    - Removed the no longer required `iconPadding`-prop (because that was just to keep the size of the icon same as before, but now we use `maxHeight`, and it will look the same as before without that)
    - Removed the size-related property description from the `README.md` (because we do not even want to encourage anyone to use dynamic icon-size)