### PR TITLE
Fix color force to black when using secureTextEntry

### DIFF
--- a/src/Input/styles.js
+++ b/src/Input/styles.js
@@ -53,7 +53,6 @@ export const input = (props = {}, stateHeight, hasValue) => {
 
   return {
     ...styles,
-    color: hasValue ? styles.color : 'black',
     ...Platform.select({
       ios: { height },
       android: {


### PR DESCRIPTION
When the field is configured with `secureTextEntry`, the `hasValue` property seem to be falsy.
The password field content doesn't take the color from props.