### PR TITLE
Feat: add overlay onPress and icon onPress

### DIFF
--- a/src/Icon/props.js
+++ b/src/Icon/props.js
@@ -8,7 +8,9 @@ export const ICON_SIZE = BASE_UNIT * 6
 export const internalPropTypes = {
   iconHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   iconPaddingTop: PropTypes.number,
-  iconWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  iconWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  iconOnPress: PropTypes.func,
+  overlayOnPress:PropTypes.func
 }
 
 export const propTypes = {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -83,7 +83,7 @@ export default class ReinputInput extends React.Component {
       >
         <Icon {...pickIconInternalProps(this.props)}
           icon={this.props.icon}
-          onPress={this.focus}
+          onPress={this.props.iconOnPress? this.props.iconOnPress :this.focus}
           marginTop={this.props.label ? this.props.labelSpacingTop : 0}
         />
         <View style={styles.container(this.props)}>
@@ -108,6 +108,7 @@ export default class ReinputInput extends React.Component {
             />
             <Icon {...pickIconInternalProps(this.props)}
               icon={this.props.iconOverlay}
+              onPress={this.props.overlayOnPress}
               overlay
             />
           </View>


### PR DESCRIPTION
To enable developers to opt for more functionalities in icons whether the main icon or overlayIcon buy adding iconOnPress as a prop and/or overlayOnPress.